### PR TITLE
Allow @ prefix for tags by default

### DIFF
--- a/main.js
+++ b/main.js
@@ -41,7 +41,7 @@ define( function( require, exports, module ) {
 		doneRegExp = /^\[x\]/i,
 		defaultSettings = {
 			regex: {
-				prefix: '(?:\\/\\*|\\/\\/) *(',
+				prefix: '(?:\\/\\*|\\/\\/) *@?(',
 				suffix: '):? *(.*?) ?(?=\\*/|\\n|$)',
 			},
 			tags: [ 'TODO', 'NOTE', 'FIX ?ME', 'CHANGES' ],


### PR DESCRIPTION
A tiny addition. This allows tags to optionally be prefixed with `@`. It's fairly common to use `@todo` as a tag.
