### PR TITLE
Fix Bug: "case":"false" in .todo file is invalid

### DIFF
--- a/main.js
+++ b/main.js
@@ -118,6 +118,7 @@ define( function( require, exports, module ) {
 				
 				// Parse .todo file.
 				userSettings = JSON.parse( content );
+				userSettings.case = userSettings.case === 'false' ? false : true;
 			} catch ( e ) {
 				// .todo exists but isn't valid JSON.
 				todoFile = false;


### PR DESCRIPTION
Because userSettings.case is 'false', it is a string. So it is not equal to the false of boolean. The code "settings.case !== false" is always true.
