### PR TITLE
Add instructions on how to use JSDoc syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,15 @@ Please note that multiline comments will not work. Todo will only return the fir
 
 `# NOTE: This is a comment as well.`
 
+In order to use [JSDoc](http://en.wikipedia.org/wiki/JSDoc) style syntax, you’ll have to create a `.todo` file in the root directory of your project with the following code:
+
+```json
+{
+	"regex": {
+		"prefix": "(?:\\/\\*|\\/\\/|#|\\*) *@?("
+	}
+}
+```
 
 ## Mark tasks as done
 


### PR DESCRIPTION
Hello @mikaeljorhult,

this pull request adds instructions on how to use JSDoc syntax with [brackets-todo](https://github.com/mikaeljorhult/brackets-todo). Let me know if you’re unhappy with the wording and I’ll update it. 
