### PR TITLE
replace deprecated currentDocumentChange

### DIFF
--- a/main.js
+++ b/main.js
@@ -371,7 +371,7 @@ define( function( require, exports, module ) {
 		
 		// Listeners bound to Brackets modules.
 		$mainViewManager
-			.on( 'currentFileChange.todo', function() {
+			.on( 'activeEditorChange.todo', function() {
 				var currentDocument = DocumentManager.getCurrentDocument(),
 					$scrollTarget;
 


### PR DESCRIPTION
replace deprecated currentDocumentChange with activeEditorChange as recommended in brackets api
http://brackets.io/docs/current/modules/document/DocumentManager.html