### PR TITLE
Call .on() directly on the Brackets modules

### DIFF
--- a/main.js
+++ b/main.js
@@ -320,11 +320,7 @@ define( function( require, exports, module ) {
 	/**
 	 * Listen for save or refresh and look for todos when needed.
 	 */
-	function registerListeners() {
-		var $mainViewManager = $( MainViewManager ),
-			$documentManager = $( DocumentManager );
-			
-		
+	function registerListeners() {		
 		// Listeners bound to Todo modules.
 		Events.subscribe( 'settings:loaded', function() {
 			// Empty array of files.
@@ -370,7 +366,7 @@ define( function( require, exports, module ) {
 		} );
 		
 		// Listeners bound to Brackets modules.
-		$mainViewManager
+		MainViewManager
 			.on( 'currentFileChange.todo', function() {
 				var currentDocument = DocumentManager.getCurrentDocument(),
 					$scrollTarget;
@@ -407,7 +403,7 @@ define( function( require, exports, module ) {
 				}
 			} );
 		
-		$documentManager			
+		DocumentManager			
 			.on( 'pathDeleted.todo', function( event, deletedPath ) {
 				var todoPath = Paths.todoFile();
 				

--- a/modules/Paths.js
+++ b/modules/Paths.js
@@ -34,7 +34,7 @@ define( function() {
 	}
 	
 	// Reload settings when new project is loaded.
-	$( ProjectManager ).on( 'projectOpen.todo', function() {
+	ProjectManager.on( 'projectOpen.todo', function() {
 		projectRoot = ProjectManager.getProjectRoot().fullPath;
 	} );
 	

--- a/modules/SettingsManager.js
+++ b/modules/SettingsManager.js
@@ -154,7 +154,7 @@ define( function( require ) {
 	}
 	
 	// Reload settings when new project is loaded.
-	$( ProjectManager ).on( 'projectOpen.todo', function() {
+	ProjectManager.on( 'projectOpen.todo', function() {
 		loadSettings();
 	} );
 	


### PR DESCRIPTION
Call .on() directly on the Brackets modules instead of wrapping them with $( ) to remove deprecation warnings with Brackets 1.2.