### PR TITLE
Added control clicking tag filters

### DIFF
--- a/main.js
+++ b/main.js
@@ -493,10 +493,25 @@ define( function( require, exports, module ) {
 				$todoPanel.find( '.file.collapsed' )
 					.trigger( 'click' );
 			} )
-			.on( 'click', '.tags a', function() {
-				// Show or hide clicked tag.
-				var $this = $( this )
-					.toggleClass( 'visible' );
+			.on( 'click', '.tags a', function( event ) {
+				var $this = $(this);
+				
+				if ( !event.ctrlKey ) {
+					// Show or hide clicked tag.
+					$this.toggleClass( 'visible' );
+				} else {
+					var numberOfVisibleTags = $this.parent().children( '.visible' ).length;
+					
+					if ( ( $this.hasClass( 'visible' ) && numberOfVisibleTags === 1 ) || numberOfVisibleTags === 0 ) {
+						// Show all tags but this one.
+						$this.parent().children().addClass( 'visible' );
+						$this.removeClass( 'visible' );
+					} else {
+						// Hide all tags but this one.
+						$this.parent().children().removeClass( 'visible' );
+						$this.addClass( 'visible' );
+					}
+				}
 				
 				// Save names of hidden tags.
 				Tags.saveHidden( $.makeArray( $this.parent().children().not( '.visible' ).map( function() {


### PR DESCRIPTION
Clicking a tag on the list of tags on the panel's toolbar will:
1. if the tag is the only one visible, make all other tags visible
2. if the tag is visible but isn't the only one, make all other tags hidden
3. if the tag is the only hidden or the tag is hidden but isn't the only one, make all tags hidden but the one clicked
