### PR TITLE
Safeguard for missing todos

### DIFF
--- a/modules/Files.js
+++ b/modules/Files.js
@@ -62,7 +62,7 @@ define(function (require) {
     Async.doInParallel(singleFile || files, readFile).always(function () {
       // Remove all files that do not have todos.
       files = files.filter(function (file) {
-        return file.todos.length > 0;
+        return file.todos && file.todos.length > 0;
       });
 
       // Sort file by path.


### PR DESCRIPTION
https://github.com/mikaeljorhult/brackets-todo/blob/master/modules/Files.js#L65 was throwing for me for some reason with

``` bash
Files.js:65 Uncaught TypeError: Cannot read property 'length' of undefined
```

This PR adds a simple safeguard for `files.todos` actually existing before trying to look up its length.