### PR TITLE
Add control clicking tags on tag list

### DIFF
--- a/modules/Tags.js
+++ b/modules/Tags.js
@@ -82,11 +82,44 @@ define(function (require) {
     Events.publish('todos:updated');
   }
 
+  /**
+   * Toggle visibility of tags, resulting in either only the given tag being visible or if it's already the only visible, all tags but given being visible.
+   *
+   * @param key
+   */
+  function toggleSolo (key) {
+    // Get tag from array.
+    var tag = _.find(tags, function (tag) {
+      return tag.key === key;
+    });
+    // Get amount of visible tags.
+    var visibleTagCount = tags.filter(function (tag) {
+      return tag.visible;
+    }).length;
+
+    // Check if given tag is the only visible.
+    if (tag.visible && visibleTagCount === 1) {
+      // Show all tags but the given.
+      tags.forEach(function (tag) {
+        tag.visible = tag.key !== key;
+      });
+    } else {
+      // Hide all tags other than the given.
+      tags.forEach(function (tag) {
+        tag.visible = tag.key === key;
+      });
+    }
+
+    // Update list of comments.
+    Events.publish('todos:updated');
+  }
+
   // Return module.
   return {
     init: init,
     get: get,
     count: count,
-    toggle: toggle
+    toggle: toggle,
+    toggleSolo: toggleSolo
   };
 });

--- a/modules/components/Tag.js
+++ b/modules/components/Tag.js
@@ -10,8 +10,13 @@ define(function (require) {
 
   // Return component.
   return Preact.createClass({
-    clickHandler: function () {
-      Tags.toggle(this.props.name);
+    clickHandler: function (event) {
+      // Check if the control key is down.
+      if (event.ctrlKey) {
+        Tags.toggleSolo(this.props.name);
+      } else {
+        Tags.toggle(this.props.name);
+      }
     },
 
     render: function () {


### PR DESCRIPTION
Allows quickly viewing TODOs of only one type by holding the control key and clicking on a tag name. Additionally, if the control clicked tag is already the only one visible, all tags but the one clicked will become visible.