### PR TITLE
Add status indicator

### DIFF
--- a/html/dialog-settings.html
+++ b/html/dialog-settings.html
@@ -72,6 +72,15 @@
 				{{ Strings.SETTINGS_DIALOG_HIDE_DONE }}
 			</label>
 		</fieldset>
+
+		<fieldset>
+			<legend>{{ Strings.SETTINGS_DIALOG_INTERFACE }}</legend>
+
+			<label for="todo-settings-show-status-indicator">
+				<input type="checkbox" name="todo-settings-show-status-indicator" id="todo-settings-show-status-indicator" />
+				{{ Strings.SETTINGS_DIALOG_SHOW_STATUS_INDICATOR }}
+			</label>
+		</fieldset>
 	</div>
 	
 	<div class="modal-footer">

--- a/main.js
+++ b/main.js
@@ -15,6 +15,8 @@ define(function (require, exports, module) {
   var AppInit = brackets.getModule('utils/AppInit');
   var ExtensionUtils = brackets.getModule('utils/ExtensionUtils');
   var Preact = brackets.getModule('thirdparty/preact');
+  var StatusBar = brackets.getModule('widgets/StatusBar');
+  var EditorManager = brackets.getModule('editor/EditorManager');
 
   // Extension modules.
   var App = require('modules/App');
@@ -34,6 +36,7 @@ define(function (require, exports, module) {
 
   // Setup extension.
   var $todoIcon = $('<a href="#" title="' + Strings.EXTENSION_NAME + '" id="brackets-todo-icon"></a>');
+  var $statusIndicator = $('<div></div>');
   var rootElement;
 
   // Get view menu.
@@ -69,6 +72,28 @@ define(function (require, exports, module) {
 
       // Render content of panel.
       Preact.render(rootElement, document.getElementById('brackets-todo-container'));
+
+      // Update status indicator.
+      if (EditorManager.getActiveEditor()) {
+        var file = Files.getFileByPath(EditorManager.getActiveEditor().document.file.fullPath);
+
+        var todoCount = !file ? 0 : file.todos.filter(function isNotDone (task) {
+          return !task.done;
+        }).length;
+
+        $statusIndicator.text(Strings.EXTENSION_NAME + ': ' + todoCount);
+      }
+    });
+
+    // Subscribe to changes to settings.
+    Events.subscribe('settings:loaded', function () {
+      var settings = Settings.get();
+
+      if (settings.interface && settings.interface.showStatusIndicator === false) {
+        $statusIndicator.hide();
+      } else {
+        $statusIndicator.show();
+      }
     });
   }
 
@@ -85,6 +110,27 @@ define(function (require, exports, module) {
       // Toggle panel when icon is clicked.
       CommandManager.execute(App.COMMAND_ID);
     }).appendTo('#main-toolbar .buttons');
+
+    // Add the file status indicator to the status bar.
+    StatusBar.addIndicator('status-todo-indicator', $statusIndicator, true, '', Strings.STATUS_INDICATOR_TITLE);
+
+    // Add listener for the status indicator.
+    $statusIndicator.click(function () {
+      // Set autoopen flag for currently open file if not closing the panel.
+      if (!SettingsManager.isExtensionEnabled() && EditorManager.getActiveEditor()) {
+        var filePath = EditorManager.getActiveEditor().document.file.fullPath;
+
+        Files.get().forEach(function (file) {
+          file.autoopened = file.path === filePath;
+        });
+      }
+
+      // Toggle panel when status indicator is clicked. Bypasses loading settings to preserve autoopened flag.
+      App.enable(!SettingsManager.isExtensionEnabled(), true);
+
+      // Force FileList to rerender.
+      Events.publish('todos:updated');
+    });
 
     // Enable extension if enabled last time Brackets was open.
     if (SettingsManager.isExtensionEnabled()) {

--- a/modules/Files.js
+++ b/modules/Files.js
@@ -38,6 +38,18 @@ define(function (require) {
   }
 
   /**
+   * Returns file by path or null if path is not found.
+   *
+   * @param path
+   * @returns {Object|null}
+   */
+  function getFileByPath (path) {
+    var index = getFileIndex(path);
+
+    return index === -1 ? null : files[index];
+  }
+
+  /**
    * Refresh all files in current project.
    */
   function refresh () {
@@ -337,6 +349,7 @@ define(function (require) {
   return {
     init: init,
     get: get,
+    getFileByPath: getFileByPath,
     refresh: refresh,
     toggle: toggle,
     collapse: collapse,

--- a/modules/SettingsDialog.js
+++ b/modules/SettingsDialog.js
@@ -41,6 +41,9 @@ define(function (require) {
       },
       hide: {
         done: $('#todo-settings-hide-done', $dialog).prop('checked')
+      },
+      interface: {
+        showStatusIndicator: $('#todo-settings-show-status-indicator', $dialog).prop('checked')
       }
     };
   }
@@ -67,6 +70,9 @@ define(function (require) {
     // Sorting and filtering.
     $('#todo-settings-sort-done').prop('checked', (settings.sort !== undefined && settings.sort.done !== undefined ? settings.sort.done : true));
     $('#todo-settings-hide-done').prop('checked', (settings.hide !== undefined && settings.hide.done !== undefined ? settings.hide.done : true));
+
+    // Interface
+    $('#todo-settings-show-status-indicator').prop('checked', (settings.interface !== undefined && settings.interface.showStatusIndicator !== undefined ? settings.interface.showStatusIndicator : true));
   }
 
   /**

--- a/nls/root/Strings.js
+++ b/nls/root/Strings.js
@@ -15,6 +15,9 @@ define({
   SHOW_OR_HIDE: 'Show/Hide',
   REFRESH: 'Refresh',
 
+  // STATUS INDICATOR.
+  STATUS_INDICATOR_TITLE: 'Displays amount of Todos in active file. Click to show Todos for active file.',
+
   // SETTINGS DIALOG.
   SETTINGS_DIALOG_TITLE: 'Todo Settings',
   SETTINGS_DIALOG_REGEX: 'Regular expression',
@@ -36,6 +39,8 @@ define({
   SETTINGS_DIALOG_SORTING_FILTERING: 'Sorting and filtering',
   SETTINGS_DIALOG_SORT_DONE: 'Move completed tasks to bottom of list.',
   SETTINGS_DIALOG_HIDE_DONE: 'Hide completed tasks.',
+  SETTINGS_DIALOG_INTERFACE: 'Interface',
+  SETTINGS_DIALOG_SHOW_STATUS_INDICATOR: 'Show button with Todo count in active file in the status bar.',
   SETTINGS_DIALOG_SAVE_FILE: 'Save to .todo',
   SETTINGS_DIALOG_RESET: 'Reset'
 });

--- a/todo.css
+++ b/todo.css
@@ -161,6 +161,12 @@
 	padding: 0 .15em;
 }
 
+/*--- STATUS INDICATOR ---*/
+#status-todo-indicator:hover {
+	text-decoration: underline;
+	cursor: pointer;
+}
+
 /*--- PROJECT WIDE SEARCH ---*/
 .brackets-todo .current .icons .expand-all,
 .brackets-todo .current .icons .collapse-all,


### PR DESCRIPTION
Adds a button to the status bar displaying the amount of Todos in the active file. Clicking on the button opens (or closes) the Todo panel and auto expands the Todos in the active file.

![screenshot_20181015_000518](https://user-images.githubusercontent.com/4833621/46922763-1bd71480-d00e-11e8-972d-71e5745e1b27.png)
